### PR TITLE
Expand ISOC acronym, for consistency

### DIFF
--- a/content/en/about.html
+++ b/content/en/about.html
@@ -110,7 +110,7 @@ slug: about
                             <div class="col-lg-4">
                                 <ul class="list-unstyled">
                                     <li>Stephen Kent (Independent)</li>
-                                    <li>Karen O'Donoghue (ISOC)</li>
+                                    <li>Karen O'Donoghue (Internet Society)</li>
                                     <li>Ivan Ristic (Independent)</li>
                                 </ul>
                             </div>


### PR DESCRIPTION
"Internet Society" and "ISOC" are both used in the same context. We could expand the acronym to keep it consistent.