### PR TITLE
Update SWE and SRE job postings

### DIFF
--- a/content/en/careers.html
+++ b/content/en/careers.html
@@ -48,7 +48,6 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
                         </div>
                     </a>
                     -->
-                    <!--
                     <a href="/careers/le-sre-sw/" class="list-group-item list-group-item-action d-flex flex-column flex-md-row align-items-center px-sm text-center text-md-left box-shadow-2">
                         <div class="mr-md-sm mb-4 mb-md-0">
                             <img alt="Let's Encrypt" src="/images/LE-Logo-LockOnly.svg" width="100" height="100" class="img-fluid">
@@ -58,7 +57,6 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
                             <p>Full time, Remote, U.S. or Canada</p>
                         </div>
                     </a>
-                    -->
                     <!--
                     <a href="/careers/le-dir-sre/" class="list-group-item list-group-item-action d-flex flex-column flex-md-row align-items-center px-sm text-center text-md-left box-shadow-2">
                         <div class="mr-md-sm mb-4 mb-md-0">

--- a/content/en/careers.html
+++ b/content/en/careers.html
@@ -48,6 +48,7 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
                         </div>
                     </a>
                     -->
+                    <!--
                     <a href="/careers/le-sre-sw/" class="list-group-item list-group-item-action d-flex flex-column flex-md-row align-items-center px-sm text-center text-md-left box-shadow-2">
                         <div class="mr-md-sm mb-4 mb-md-0">
                             <img alt="Let's Encrypt" src="/images/LE-Logo-LockOnly.svg" width="100" height="100" class="img-fluid">
@@ -57,6 +58,7 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
                             <p>Full time, Remote, U.S. or Canada</p>
                         </div>
                     </a>
+                    -->
                     <!--
                     <a href="/careers/le-dir-sre/" class="list-group-item list-group-item-action d-flex flex-column flex-md-row align-items-center px-sm text-center text-md-left box-shadow-2">
                         <div class="mr-md-sm mb-4 mb-md-0">

--- a/content/en/careers/le-sr-sw-eng.html
+++ b/content/en/careers/le-sr-sw-eng.html
@@ -24,7 +24,7 @@ Location: <strong>100% Remote within US and Canada</strong><br>
 <p>We’re looking for an additional software engineer. Maybe that’s you! Here’s what our software engineering team does:</p>
 
 <ul>
-	<li>We maintain <a href="https://github.com/letsencrypt/boulder">Boulder</a>, the server software that runs our Automated Certificate Management Environment (ACME) API. This includes:</li>
+	<li>We maintain <a href="https://github.com/letsencrypt/boulder">Boulder</a>, the server software that runs our Automated Certificate Management Environment (<a href="https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment">ACME</a>) API. This includes:</li>
 		<ul>
 			<li>Diagnosing and fixing bugs</li>
 			<li>Finding scaling problems and fixing them</li>
@@ -33,7 +33,7 @@ Location: <strong>100% Remote within US and Canada</strong><br>
 	<li>We maintain <a href="https://github.com/letsencrypt/pebble">Pebble</a>, a “small size” version of Boulder that helps developers test their ACME clients.</li>
 	<li>We contribute to open source projects we depend on.</li>
 	<li>We help run a community forum that helps developers and end users fix their problems, and moderate comments to ensure everything stays on-track. We are happy to say ours is the friendliest and most supportive HTTPS-related forum around.</li>
-	<li>We participate in an on call rotation, with infrequent pages and no strict service level thanks to our wonderful SRE colleagues. We value protecting our teammates from burnout and accomodate people's schedules as needed.</li>
+	<li>We participate in an on call rotation, with infrequent pages and no strict service level thanks to our wonderful SRE colleagues. We value protecting our teammates from burnout and accommodate people's schedules as needed.</li>
 	<li>We develop expertise on Public Key Infrastructure (PKI) and advise the rest of the team on related changes.</li>
 	<li>We participate in standards-development processes at the <a href="https://www.ietf.org">IETF</a> and elsewhere.</li>
 	<li>We develop new products and new features. For instance, right now we’re planning work on an extra-secure memory-safe recursive resolver.</li>

--- a/content/en/careers/le-sr-sw-eng.html
+++ b/content/en/careers/le-sr-sw-eng.html
@@ -24,18 +24,18 @@ Location: <strong>100% Remote within US and Canada</strong><br>
 <p>We’re looking for an additional software engineer. Maybe that’s you! Here’s what our software engineering team does:</p>
 
 <ul>
-	<li>We maintain Boulder, the server software that runs our ACME API. This includes:</li>
+	<li>We maintain <a href="https://github.com/letsencrypt/boulder">Boulder</a>, the server software that runs our Automated Certificate Management Environment (ACME) API. This includes:</li>
 		<ul>
 			<li>Diagnosing and fixing bugs</li>
 			<li>Finding scaling problems and fixing them</li>
 			<li>Developing new features</li>
 		</ul>
-	<li>We maintain Pebble, a “small size” version of Boulder that helps developers test their ACME clients.</li>
+	<li>We maintain <a href="https://github.com/letsencrypt/pebble">Pebble</a>, a “small size” version of Boulder that helps developers test their ACME clients.</li>
 	<li>We contribute to open source projects we depend on.</li>
 	<li>We help run a community forum that helps developers and end users fix their problems, and moderate comments to ensure everything stays on-track. We are happy to say ours is the friendliest and most supportive HTTPS-related forum around.</li>
-	<li>We participate in an on call rotation. We value protecting our teammates from burnout and accomodate people's schedules as needed.</li>
-	<li>We develop expertise on Public Key Infrastructure and advise the rest of the team on related changes.</li>
-	<li>We participate in standards-development processes at IETF and elsewhere.</li>
+	<li>We participate in an on call rotation, with infrequent pages and no strict service level thanks to our wonderful SRE colleagues. We value protecting our teammates from burnout and accomodate people's schedules as needed.</li>
+	<li>We develop expertise on Public Key Infrastructure (PKI) and advise the rest of the team on related changes.</li>
+	<li>We participate in standards-development processes at the <a href="https://www.ietf.org">IETF</a> and elsewhere.</li>
 	<li>We develop new products and new features. For instance, right now we’re planning work on an extra-secure memory-safe recursive resolver.</li>
 	<li>We cross-train with our SRE team, learning some of their tools and processes, giving feedback and input on decision making, and receiving feedback on the tools we develop to be deployed by SRE.</li>
 </ul>
@@ -43,15 +43,17 @@ Location: <strong>100% Remote within US and Canada</strong><br>
 <p>Here’s what we’d like you to bring to our team:</p>
 
 <ul>
-	<li>At least a year’s experience writing code in Go, or a couple of years in another compiled language.</li>
-	<li>Attention to detail and a willingness to spend the time it takes to get things right.</li>
+	<li>One year’s experience writing code in Go, or two years in another compiled language.</li>
+	<li>Attention to detail and a willingness to take time to think things through and do them the right way.</li>
 	<li>Experience writing unit tests and integration tests.</li>
 	<li>Excellent communication, organization, and prioritization skills.</li>
 </ul>
 
 <p>Prior experience with cryptography and PKI is not required. We will provide on-the-job training.</p>
 
-<p>To apply, please submit your resume to: <a href="mailto:careers@letsencrypt.org">careers@letsencrypt.org</a></p>
+<p>Our team is 100% remote, and we will help you get your home office in good shape, including reimbursing internet and phone expenses. Other benefits include excellent health insurance, a 100% match for 401k contributions, and flexible time off and parental leave policies.</p>
+
+<p>To apply, please submit your resume to: <a href="mailto:careers@letsencrypt.org">careers@letsencrypt.org</a>. You can expect an initial reply within one week.</p>
 
 </div>
 </section>

--- a/content/en/careers/le-sre-sw.html
+++ b/content/en/careers/le-sre-sw.html
@@ -10,8 +10,8 @@ slug: le-sre-sw
 <div class="container">
 
 <p>
-Posted: <strong>June 23, 2020</strong><br>
-Position Status: <strong>Open</strong><br>
+Posted: <strong>N/A</strong><br>
+Position Status: <strong>Closed</strong><br>
 Location: <strong>100% Remote within US and Canada</strong><br>
 </p>
 

--- a/content/en/careers/le-sre-sw.html
+++ b/content/en/careers/le-sre-sw.html
@@ -1,12 +1,27 @@
 ---
 title: "Let's Encrypt: Site Reliability Engineer"
 subtitle: Help us build a more secure and privacy-respecting Internet.
+images:
+  - /images/le-logo-standard.png
+slug: le-sre-sw
 ---
 
 <section class="slice slice-sm">
 <div class="container">
 
-<p>To apply, please submit your resume to: <a href="mailto:careers@letsencrypt.org">careers@letsencrypt.org</a></p>
+<p>
+Posted: <strong>June 23, 2020</strong><br>
+Position Status: <strong>Open</strong><br>
+Location: <strong>100% Remote within US and Canada</strong><br>
+</p>
+
+<div class="card border-0 pic-quote-right">
+    <img alt="Let's Encrypt" width="250" class="img-fluid p-3" src="/images/LE-Logo-Standard.svg">
+</div>
+
+<p>We’re making HTTPS easier for developers to use, we’re doing it at scale, and we need your help. We’re a first-of-our-kind Certificate Authority (CA). We make certificates available to anyone, for free, and we offer an API to do it. This means more people can enable HTTPS on their websites, with less work. That protects everyone’s web traffic from snoops, and makes us all safer.</p>
+
+<p>We’re looking for an additional site reliability engineer. Maybe that’s you!</p>
 
 <h2>What You Will Do</h2>
 
@@ -30,7 +45,7 @@ subtitle: Help us build a more secure and privacy-respecting Internet.
 	<li>Two years professional experience as a software developer</li>
     <li>An understanding of why writing tests for software is critical</li>
     <li>A willingness to travel approximately three times per year</li>
-    <li>A willingness to be on-call (time split between six people)</li>
+    <li>A willingness to be on-call (time split between eight people)</li>
     <li>Personal organization ability so that people can depend on you (e.g. task lists, calendar management)</li>
 </ul>
 


### PR DESCRIPTION
Update the Senior Software Engineer job posting based on my
feedback from having gone through the hiring process with this
same posting recently. In addition, re-open the Site Reliability
Engineer posting.