### PR TITLE
Reorder icons at the bottom of the page.

### DIFF
--- a/content/en/careers.html
+++ b/content/en/careers.html
@@ -82,6 +82,46 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
             <div class="col-lg-4">
                 <div class="d-flex align-items-start">
                     <div class="icon icon-lg text-primary">
+                        <img alt="Inclusion" src="/images/icons/diversity-1-black.svg" class="img-fluid">
+                    </div>
+                    <div class="icon-text px-4">
+                        <h5 class="heading h5">Inclusion</h5>
+                        <p class="mb-0">We need a diverse team to serve a diverse global community. We encourage applicants of all genders, ages, abilities, orientations, and ethnicities to apply.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="d-flex align-items-start">
+                    <div class="icon icon-lg text-primary">
+                        <img alt="Flexibility" src="/images/icons/flexible-1-black.svg" class="img-fluid">
+                    </div>
+                    <div class="icon-text px-4">
+                        <h5 class="heading h5">Flexibility</h5>
+                        <p class="mb-0">Work from anywhere in the U.S. or Canada with flexible PTO and generous parental leave policies.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="d-flex align-items-start">
+                    <div class="icon icon-lg text-primary">
+                        <img alt="Open Source" src="/images/icons/code-1-black.svg" class="img-fluid">
+                    </div>
+                    <div class="icon-text px-4">
+                        <h5 class="heading h5">Open Source</h5>
+                        <p class="mb-0">We have a strong preference for using, publishing, and contributing back to open source software.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="slice slice-sm">
+    <div class="container">
+        <div class="row row-grid">
+            <div class="col-lg-4">
+                <div class="d-flex align-items-start">
+                    <div class="icon icon-lg text-primary">
                         <img alt="Impact" src="/images/icons/globe-1-black.svg" class="img-fluid">
                     </div>
                     <div class="icon-text px-4">
@@ -116,42 +156,3 @@ description: "Billions of people rely on ISRG / Let's Encrypt to operate critica
     </div>
 </section>
 
-<section class="slice slice-sm">
-    <div class="container">
-        <div class="row row-grid">
-            <div class="col-lg-4">
-                <div class="d-flex align-items-start">
-                    <div class="icon icon-lg text-primary">
-                        <img alt="Inclusion" src="/images/icons/diversity-1-black.svg" class="img-fluid">
-                    </div>
-                    <div class="icon-text px-4">
-                        <h5 class="heading h5">Inclusion</h5>
-                        <p class="mb-0">We need a diverse team to serve a diverse global community. We encourage applicants of all genders, ages, abilities, orientations, and ethnicities to apply.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-lg-4">
-                <div class="d-flex align-items-start">
-                    <div class="icon icon-lg text-primary">
-                        <img alt="Flexibility" src="/images/icons/flexible-1-black.svg" class="img-fluid">
-                    </div>
-                    <div class="icon-text px-4">
-                        <h5 class="heading h5">Flexibility</h5>
-                        <p class="mb-0">Work from anywhere in the U.S. or Canada with flexible PTO and generous parental leave policies.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-lg-4">
-                <div class="d-flex align-items-start">
-                    <div class="icon icon-lg text-primary">
-                        <img alt="Open Source" src="/images/icons/code-1-black.svg" class="img-fluid">
-                    </div>
-                    <div class="icon-text px-4">
-                        <h5 class="heading h5">Open Source</h5>
-                        <p class="mb-0">We have a strong preference for using, publishing, and contributing back to open source software.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>


### PR DESCRIPTION
On my browser, the second row of icons is below the fold and could
easily be missed, but I think that second row has some of the things we
most want to convey to potential applicants about our values.

This just moves the bottom row to the top row (even though GitHub
renders it as a series of edits).